### PR TITLE
Fix website styling and SCSS imports

### DIFF
--- a/src/components/next-step/style.css
+++ b/src/components/next-step/style.css
@@ -1,5 +1,5 @@
 .next-step {
-  margin-top: 241px;
+  margin-top: 80px;
   margin-bottom: 80px;
 }
 

--- a/src/layout/style.css
+++ b/src/layout/style.css
@@ -5,10 +5,11 @@
 
 .next-step {
     margin-top: 58px !important;
-    margin-bottom: -130px !important;
+    margin-bottom: 0 !important;
 }
 .sticky-section-switch {
     transform: translate3d(0,0,0);
+    margin-bottom: 50px;
   }
 
   .children-wrapper {


### PR DESCRIPTION
Adjust margins for `next-step` and `sticky-section-switch` components to fix footer overlapping and improve page layout.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-51d47d0b-6964-4fa6-badc-77194a8c27e4) · [Cursor](https://cursor.com/background-agent?bcId=bc-51d47d0b-6964-4fa6-badc-77194a8c27e4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)