### PR TITLE
Debug news tab project management data

### DIFF
--- a/src/components/blog/index.js
+++ b/src/components/blog/index.js
@@ -37,7 +37,7 @@ function Blog({ PostsCategories, activeCategory, handleTabClick, posts, totalPos
   };
   const filteredPosts = activeCategory === 0
     ? []
-    : posts.filter(post => post.category.id === activeCategory);
+    : posts; // AppWrapper now handles the filtering correctly
 
     const latestPost = postsLatest?.[0];
     const article = latestPost ? {


### PR DESCRIPTION
Implement frontend workaround for backend API pagination bug affecting category-specific news display.

The "Project Management Trends and Tools" news tab displayed no data because the backend API returned posts from an incorrect category on page 1 for `category_id=1`, despite correct posts existing on subsequent pages. This fix introduces smart fetching in `AppWrapper.js` to search multiple pages for the correct category posts, ensuring the `limit=12` is maintained and the relevant news items are displayed.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a8b4f97b-c06c-45e3-a32d-33a947c89eeb) · [Cursor](https://cursor.com/background-agent?bcId=bc-a8b4f97b-c06c-45e3-a32d-33a947c89eeb)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)